### PR TITLE
fix: correct the alignment of the day tabs on the homepage for device with smaller screens

### DIFF
--- a/src/app/(home)/_components/ChartBox/index.tsx
+++ b/src/app/(home)/_components/ChartBox/index.tsx
@@ -22,7 +22,7 @@ function ChartBox(props: PropsType) {
               <button
                 key={`day-filter-${filterItem.days}`}
                 onClick={() => setCurrentDays(filterItem.days)}
-                className={`text-10 w-[86px] md:w-[90px] md:text-14 rounded-soft px-15 py-5 md:py-10 font-normal	 ${
+                className={`text-10 flex-1 md:flex-initial md:w-[90px] md:text-14 rounded-soft px-15 py-5 md:py-10 font-normal	 ${
                   currentDays === filterItem.days
                     ? 'bg-secondary-500 text-baseForeground'
                     : 'bg-transparent text-neutral-200'


### PR DESCRIPTION
The day tabs are not properly aligned. The 90-day tab has excessive spacing on the right side :
![2](https://github.com/user-attachments/assets/27c850b3-eb67-4335-98f4-84144afb8952)
