### PR TITLE
fix: update broken links for sdk, api anchor texts

### DIFF
--- a/src/components/common/Footer/Footer.constants.ts
+++ b/src/components/common/Footer/Footer.constants.ts
@@ -15,12 +15,12 @@ export const products: ListItemProps[] = [
     openInNewTab: true,
   },
   {
-    location: 'https://rango.exchange/apis',
+    location: 'https://rango.exchange/sdk-apis',
     title: 'SDK',
     openInNewTab: false,
   },
   {
-    location: 'https://rango.exchange/apis',
+    location: 'https://rango.exchange/sdk-apis',
     title: 'API',
     openInNewTab: false,
   },


### PR DESCRIPTION
Replaced 404 links with correct URLs for `SDK` and `API` in the footer.
The link for `Widget` was already correct