### PR TITLE
fix: prioritize tx hash in search

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -44,6 +44,12 @@ function Search(props: PropsType) {
   );
 }
 
+/*
+ *
+ * NOTE:
+ * The code has been developed with a wrong assumption here which is always the first one is the one we should detect the type of `query` with.
+ * If there is more than one result, we should let the user select the one looking for.
+ */
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context?.query || {};
   const result = await getSearchResult(query as string);
@@ -57,8 +63,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  if (result?.length && result[0].matchType === MATCH_TYPE.TXHASH) {
-    const { requestId } = result[0];
+  // HOTFIX: We priotorize transaction hash. check the note on top of the function.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const matchedWithTxHash = result?.find((item: any) => {
+    return item.matchType === MATCH_TYPE.TXHASH;
+  });
+
+  if (matchedWithTxHash) {
+    const { requestId } = matchedWithTxHash;
     if (requestId)
       return {
         redirect: {


### PR DESCRIPTION
# Summary
`result` is a list, we have a incorrect assumption on the client that the first one is main. this PR is a patch to prioritize tx hash. 