### PR TITLE
stop indexing the search and swaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:icons": "svgr svgs/resources/ --config-file svgs/configs/.svgrrc.default.cjs && prettier -w ./components/icons"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@artsy/fresnel": "^7.1.3",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,7 @@
+const HOST = 'https://explorer.rango.exchange';
+export default function robots() {
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    sitemap: `${HOST}/sitemap.xml`,
+  };
+}

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,8 +1,0 @@
-User-Agent: *
-Allow: /
-
-# Host
-Host: https://rango.exchange
-
-# Sitemaps
-Sitemap: https://rango.exchange/sitemap.xml

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,7 @@ export async function generateMetadata({
 }) {
   return {
     title: `Address ${searchParams.query}`,
+    robots: { index: false, follow: false },
   };
 }
 /*

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,21 +11,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${WEBSITE_URL}/statistics`,
       priority: 0.8,
     },
-    {
-      url: `${WEBSITE_URL}/search`,
-      priority: 0.8,
-    },
-    {
-      url: `${WEBSITE_URL}/swap`,
-      priority: 0.8,
-    },
-    {
-      url: `https://app.rango.exchange/`,
-      priority: 0.9,
-    },
-    {
-      url: `https://docs.rango.exchange`,
-      priority: 0.9,
-    },
   ];
 }

--- a/src/app/swap/[id]/page.tsx
+++ b/src/app/swap/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Suspense } from 'react';
 export async function generateMetadata({ params }: { params: { id: string } }) {
   return {
     title: `Swap ${params.id}`,
+    robots: { index: false, follow: false },
   };
 }
 


### PR DESCRIPTION
Google is indexing thousands of low-value scanner pages — one per wallet address, txHash, and swap. They have no SEO value and hurt host quality.

Caused by:

[src/app/robots.txt](https://rango.youtrack.cloud/src/app/robots.txt) — Sitemap: points at the wrong host, includes a deprecated Host: line.
[src/app/sitemap.ts](https://rango.youtrack.cloud/src/app/sitemap.ts) — lists /swap and cross-host URLs.
/search/page.tsx and /swap/[id]/page.tsx don't set noindex.